### PR TITLE
Modified enqueue of script and styles

### DIFF
--- a/customizer/alpha-color-picker/alpha-color-picker.php
+++ b/customizer/alpha-color-picker/alpha-color-picker.php
@@ -55,7 +55,7 @@ class Customize_Alpha_Color_Control extends WP_Customize_Control {
 		);
 		wp_enqueue_style(
 			'alpha-color-picker',
-			get_stylesheet_directory_uri() . str_replace( str_replace('\\', '/', get_stylesheet_directory()), '', str_replace('\\', '/', __DIR__) ) . 'alpha-color-picker.css',
+			get_stylesheet_directory_uri() . str_replace( str_replace('\\', '/', get_stylesheet_directory()), '', str_replace('\\', '/', __DIR__) ) . '/alpha-color-picker.css',
 			array( 'wp-color-picker' ),
 			'1.0.0'
 		);

--- a/customizer/alpha-color-picker/alpha-color-picker.php
+++ b/customizer/alpha-color-picker/alpha-color-picker.php
@@ -48,14 +48,14 @@ class Customize_Alpha_Color_Control extends WP_Customize_Control {
 	public function enqueue() {
 		wp_enqueue_script(
 			'alpha-color-picker',
-			get_stylesheet_directory_uri() . '/admin/customizer/alpha-color-picker/alpha-color-picker.js',
+			get_stylesheet_directory_uri() . str_replace( str_replace('\\', '/', get_stylesheet_directory()), '', str_replace('\\', '/', __DIR__) ) . '/alpha-color-picker.js',
 			array( 'jquery', 'wp-color-picker' ),
 			'1.0.0',
 			true
 		);
 		wp_enqueue_style(
 			'alpha-color-picker',
-			get_stylesheet_directory_uri() . '/admin/customizer/alpha-color-picker/alpha-color-picker.css',
+			get_stylesheet_directory_uri() . str_replace( str_replace('\\', '/', get_stylesheet_directory()), '', str_replace('\\', '/', __DIR__) ) . 'alpha-color-picker.css',
 			array( 'wp-color-picker' ),
 			'1.0.0'
 		);


### PR DESCRIPTION
When initially deploying the alpha color picker, the CSS and JS URIs are hard-coded as those the original author uses (/admin/customizer/alpha-color-picker/alpha-color-picker.js) . Other developers may wish to locate the alpha color picker in another folder in the theme (e.g. in inc folder)

The added code works out what the URI of the folder the php file is located in, and therefore works out the correct URI of the CSS and JS files without requiring a developer to edit the source code of the alpha color picker, allowing for easier updating without having to edit the URI everytime.

Tested on Windows and Linux, WordPress 4.3.