### PR TITLE
Change enqueue method for script and style.

### DIFF
--- a/customizer/alpha-color-picker/alpha-color-picker.php
+++ b/customizer/alpha-color-picker/alpha-color-picker.php
@@ -47,7 +47,7 @@ class Customize_Alpha_Color_Control extends WP_Customize_Control {
 	 */
 	public function enqueue() {
 
-		$default_script_location = get_stylesheet_directory_uri() . '/admin/customizer/alpha-color-picker/alpha-color-picker.js';
+		$default_script_location = get_template_directory_uri() . '/admin/customizer/alpha-color-picker/alpha-color-picker.js';
 
 		wp_enqueue_script(
 			'alpha-color-picker',
@@ -57,7 +57,7 @@ class Customize_Alpha_Color_Control extends WP_Customize_Control {
 			true
 		);
 
-		$default_styles_location = get_stylesheet_directory_uri() . '/admin/customizer/alpha-color-picker/alpha-color-picker.css';
+		$default_styles_location = get_template_directory_uri() . '/admin/customizer/alpha-color-picker/alpha-color-picker.css';
 
 		wp_enqueue_style(
 			'alpha-color-picker',

--- a/customizer/alpha-color-picker/alpha-color-picker.php
+++ b/customizer/alpha-color-picker/alpha-color-picker.php
@@ -46,16 +46,22 @@ class Customize_Alpha_Color_Control extends WP_Customize_Control {
 	 * stand alone class we'll register and enqueue them here.
 	 */
 	public function enqueue() {
+
+		$default_script_location = get_stylesheet_directory_uri() . '/admin/customizer/alpha-color-picker/alpha-color-picker.js';
+
 		wp_enqueue_script(
 			'alpha-color-picker',
-			get_stylesheet_directory_uri() . '/admin/customizer/alpha-color-picker/alpha-color-picker.js',
+			apply_filters('alpha-color-picker-scripts', $default_script_location),
 			array( 'jquery', 'wp-color-picker' ),
 			'1.0.0',
 			true
 		);
+
+		$default_styles_location = get_stylesheet_directory_uri() . '/admin/customizer/alpha-color-picker/alpha-color-picker.css';
+
 		wp_enqueue_style(
 			'alpha-color-picker',
-			get_stylesheet_directory_uri() . '/admin/customizer/alpha-color-picker/alpha-color-picker.css',
+			apply_filters('alpha-color-picker-styles', $default_styles_location),
 			array( 'wp-color-picker' ),
 			'1.0.0'
 		);

--- a/customizer/alpha-color-picker/alpha-color-picker.php
+++ b/customizer/alpha-color-picker/alpha-color-picker.php
@@ -70,24 +70,28 @@ class Customize_Alpha_Color_Control extends WP_Customize_Control {
 		if ( is_array( $this->palette ) ) {
 			$palette = implode( '|', $this->palette );
 		} else {
-			// Default to true.
+			// Default to true
 			$palette = ( false === $this->palette || 'false' === $this->palette ) ? 'false' : 'true';
 		}
 
 		// Support passing show_opacity as string or boolean. Default to true.
 		$show_opacity = ( false === $this->show_opacity || 'false' === $this->show_opacity ) ? 'false' : 'true';
 
-		// Begin the output. ?>
-		<label>
-			<?php // Output the label and description if they were passed in.
-			if ( isset( $this->label ) && '' !== $this->label ) {
-				echo '<span class="customize-control-title">' . sanitize_text_field( $this->label ) . '</span>';
-			}
-			if ( isset( $this->description ) && '' !== $this->description ) {
-				echo '<span class="description customize-control-description">' . sanitize_text_field( $this->description ) . '</span>';
-			} ?>
-			<input class="alpha-color-control" type="text" data-show-opacity="<?php echo $show_opacity; ?>" data-palette="<?php echo esc_attr( $palette ); ?>" data-default-color="<?php echo esc_attr( $this->settings['default']->default ); ?>" <?php $this->link(); ?>  />
-		</label>
+		// Output the label if passed in
+		if ( isset( $this->label ) && '' !== $this->label ) {
+			echo '<span class="customize-control-title">' . sanitize_text_field( $this->label ) . '</span>';
+		}
+
+		// Output the description if passed in	
+		if ( isset( $this->description ) && '' !== $this->description ) {
+			echo '<span class="description customize-control-description">' . sanitize_text_field( $this->description ) . '</span>';
+		} 
+		?>
+		<div class="customize-control-content">
+			<label>
+				<input class="alpha-color-control" type="text" data-show-opacity="<?php echo $show_opacity; ?>" data-palette="<?php echo esc_attr( $palette ); ?>" data-default-color="<?php echo esc_attr( $this->settings['default']->default ); ?>" <?php $this->link(); ?>  />
+			</label>
+		</div>
 		<?php
 	}
 }


### PR DESCRIPTION
Altering the enqueue method from `get_stylesheet_directory_uri` to `get_template_directory_uri` allows child themes to use the Alpha Color Picker.