### PR TITLE
Make the width of the input field flexible.

### DIFF
--- a/customizer/alpha-color-picker/alpha-color-picker.css
+++ b/customizer/alpha-color-picker/alpha-color-picker.css
@@ -11,17 +11,16 @@
 }
 
 .customize-control-alpha-color .wp-picker-open + .wp-picker-input-wrap {
-	width: 100%;
+	display: flex;
+}
+
+.customize-control-alpha-color .wp-picker-open + .wp-picker-input-wrap label {
+	flex-grow: 1;
 }
 
 .customize-control-alpha-color .wp-picker-input-wrap input[type="text"].wp-color-picker.alpha-color-control {
-	float: left;
-	width: 195px;
-}
-
-.customize-control-alpha-color .wp-picker-input-wrap .button {
-	margin-left: 0;
-	float: right;
+	height: 100%;
+	width: 100%;
 }
 
 .wp-picker-container .wp-picker-open ~ .wp-picker-holder .alpha-color-picker-container {
@@ -111,17 +110,4 @@
 	border-radius: 3px;
 	padding: 0;
 	margin-top: -24px;
-}
-
-@media only screen and (max-width: 782px) {
-	.customize-control-alpha-color .wp-picker-input-wrap input[type="text"].wp-color-picker.alpha-color-control {
-		width: 184px;
-	}
-}
-
-@media only screen and (max-width: 640px) {
-	.customize-control-alpha-color .wp-picker-input-wrap input[type="text"].wp-color-picker.alpha-color-control {
-		width: 172px;
-		height: 33px;
-	}
 }

--- a/customizer/alpha-color-picker/alpha-color-picker.php
+++ b/customizer/alpha-color-picker/alpha-color-picker.php
@@ -77,15 +77,15 @@ class Customize_Alpha_Color_Control extends WP_Customize_Control {
 		// Support passing show_opacity as string or boolean. Default to true.
 		$show_opacity = ( false === $this->show_opacity || 'false' === $this->show_opacity ) ? 'false' : 'true';
 
-		// Begin the output. ?>
+		// Begin the output.
+		if ( isset( $this->label ) && '' !== $this->label ) {
+			echo '<span class="customize-control-title">' . sanitize_text_field( $this->label ) . '</span>';
+		}
+		if ( isset( $this->description ) && '' !== $this->description ) {
+			echo '<span class="description customize-control-description">' . sanitize_text_field( $this->description ) . '</span>';
+		}
+		?>
 		<label>
-			<?php // Output the label and description if they were passed in.
-			if ( isset( $this->label ) && '' !== $this->label ) {
-				echo '<span class="customize-control-title">' . sanitize_text_field( $this->label ) . '</span>';
-			}
-			if ( isset( $this->description ) && '' !== $this->description ) {
-				echo '<span class="description customize-control-description">' . sanitize_text_field( $this->description ) . '</span>';
-			} ?>
 			<input class="alpha-color-control" type="text" data-show-opacity="<?php echo $show_opacity; ?>" data-palette="<?php echo esc_attr( $palette ); ?>" data-default-color="<?php echo esc_attr( $this->settings['default']->default ); ?>" <?php $this->link(); ?>  />
 		</label>
 		<?php


### PR DESCRIPTION
In other languages, the button 'Default' could be placed underneath the
input because the button text was longer. This commit makes sure the
input and button are always on the same line, using flexbox.