### PR TITLE
Show the label and description always.

### DIFF
--- a/customizer/alpha-color-picker/alpha-color-picker.php
+++ b/customizer/alpha-color-picker/alpha-color-picker.php
@@ -77,15 +77,15 @@ class Customize_Alpha_Color_Control extends WP_Customize_Control {
 		// Support passing show_opacity as string or boolean. Default to true.
 		$show_opacity = ( false === $this->show_opacity || 'false' === $this->show_opacity ) ? 'false' : 'true';
 
-		// Begin the output. ?>
+		// Begin the output.
+		if ( isset( $this->label ) && '' !== $this->label ) {
+			echo '<span class="customize-control-title">' . sanitize_text_field( $this->label ) . '</span>';
+		}
+		if ( isset( $this->description ) && '' !== $this->description ) {
+			echo '<span class="description customize-control-description">' . sanitize_text_field( $this->description ) . '</span>';
+		}
+		?>
 		<label>
-			<?php // Output the label and description if they were passed in.
-			if ( isset( $this->label ) && '' !== $this->label ) {
-				echo '<span class="customize-control-title">' . sanitize_text_field( $this->label ) . '</span>';
-			}
-			if ( isset( $this->description ) && '' !== $this->description ) {
-				echo '<span class="description customize-control-description">' . sanitize_text_field( $this->description ) . '</span>';
-			} ?>
 			<input class="alpha-color-control" type="text" data-show-opacity="<?php echo $show_opacity; ?>" data-palette="<?php echo esc_attr( $palette ); ?>" data-default-color="<?php echo esc_attr( $this->settings['default']->default ); ?>" <?php $this->link(); ?>  />
 		</label>
 		<?php


### PR DESCRIPTION
Not only when the color picker is expanded.

Fixes #20