### PR TITLE
Rearrange html on color picker to match template on wp codex

### DIFF
--- a/customizer/alpha-color-picker/alpha-color-picker.php
+++ b/customizer/alpha-color-picker/alpha-color-picker.php
@@ -78,16 +78,19 @@ class Customize_Alpha_Color_Control extends WP_Customize_Control {
 		$show_opacity = ( false === $this->show_opacity || 'false' === $this->show_opacity ) ? 'false' : 'true';
 
 		// Begin the output. ?>
-		<label>
-			<?php // Output the label and description if they were passed in.
+		<?php // Output the label and description if they were passed in.
 			if ( isset( $this->label ) && '' !== $this->label ) {
 				echo '<span class="customize-control-title">' . sanitize_text_field( $this->label ) . '</span>';
 			}
 			if ( isset( $this->description ) && '' !== $this->description ) {
 				echo '<span class="description customize-control-description">' . sanitize_text_field( $this->description ) . '</span>';
-			} ?>
-			<input class="alpha-color-control" type="text" data-show-opacity="<?php echo $show_opacity; ?>" data-palette="<?php echo esc_attr( $palette ); ?>" data-default-color="<?php echo esc_attr( $this->settings['default']->default ); ?>" <?php $this->link(); ?>  />
-		</label>
+		} ?>
+		<div class="customize-control-content">
+                	<label>
+                    		<span class="screen-reader-text"><?php echo isset( $this->label ) && '' !== $this->label ? $this->label : "Alpha Color Picker"; ?></span>
+                    		<input class="alpha-color-control" type="text" data-show-opacity="<?php echo $show_opacity; ?>" data-palette="<?php echo esc_attr( $palette ); ?>" data-default-color="<?php echo esc_attr( $this->settings['default']->default ); ?>" <?php $this->link(); ?>  />
+                	</label>
+            	</div>
 		<?php
 	}
 }


### PR DESCRIPTION
Match template from: 
https://developer.wordpress.org/reference/classes/wp_customize_color_control/