### PR TITLE
The input filed with hex/rgb values always shown

### DIFF
--- a/alpha-color-picker/alpha-color-picker.css
+++ b/alpha-color-picker/alpha-color-picker.css
@@ -6,7 +6,7 @@
 	border-bottom: none;
 }
 
-.alpha-color-picker-wrap .wp-picker-input-wrap {
+.alpha-color-picker-wrap .wp-picker-open+.wp-picker-input-wrap {
 	display: block;
 }
 


### PR DESCRIPTION
Fixes issue [#29](https://github.com/BraadMartin/components/issues/29).

The input field with hex/rgb values always shown. The correct behaviour: The input filed should be hidden until a user clicks on the color button, then we show the input field.